### PR TITLE
Revert "feat: use gnome instead of KDE [ISO]"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,18 +5,18 @@ on:
     branches:
       - main
   schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+    - cron: '05 10 * * *'  # 10:05am UTC everyday
   push:
     branches:
       - main
     paths-ignore:
-      - "**.md"
-      - "**.txt"
+      - '**.md'
+      - '**.txt'
   workflow_dispatch:
 
 env:
   MY_IMAGE_NAME: "isengard"
-  ARG_BASE_IMAGE_NAME: "bazzite-gnome"
+  ARG_BASE_IMAGE_NAME: "bazzite"
   ARG_IMAGE_TAG: "stable"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
 

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -20,6 +20,7 @@ jobs:
       packages: write
       id-token: write
     steps:
+
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
 
@@ -59,7 +60,7 @@ jobs:
       - name: Get Bazzite KDE Flatpaks
         shell: bash
         run: |
-          curl --fail -L -o ${{ github.workspace }}/${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}/bazzite_flatpaks https://raw.githubusercontent.com/ublue-os/bazzite/main/installer/gnome_flatpaks/flatpaks
+          curl --fail -L -o ${{ github.workspace }}/${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}/bazzite_flatpaks https://raw.githubusercontent.com/ublue-os/bazzite/main/installer/kde_flatpaks/flatpaks
       - name: Determine Flatpak Dependencies
         id: flatpak_dependencies
         shell: bash
@@ -98,11 +99,11 @@ jobs:
           arch: x86_64
           image_name: ${{ env.image_name }}
           image_repo: ghcr.io/noelmiller
-          variant: "Kinoite"
+          variant: 'Kinoite'
           version: ${{ env.major_version }}
           image_tag: ${{ steps.generate-tag.outputs.tag }}
-          secure_boot_key_url: "https://github.com/ublue-os/akmods/raw/main/certs/public_key.der"
-          enrollment_password: "ublue-os"
+          secure_boot_key_url: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
+          enrollment_password: 'ublue-os'
           iso_name: ${{ env.image_name }}-${{ steps.generate-tag.outputs.tag }}.iso
           enable_cache_dnf: "false"
           enable_cache_skopeo: "false"

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-bazzite-gnome}"
+ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-bazzite}"
 ARG IMAGE_TAG="${IMAGE_TAG:-stable}"
 
 FROM ghcr.io/ublue-os/${BASE_IMAGE_NAME}:${IMAGE_TAG} AS isengard
@@ -8,7 +8,7 @@ COPY scripts /scripts
 
 RUN /scripts/preconfigure.sh && \
     /scripts/install_packages.sh && \
-    /scripts/configure_gnome.sh && \
+    /scripts/configure_kde.sh && \
     /scripts/enable_services.sh && \
     /scripts/just.sh && \
     /scripts/cleanup.sh && \

--- a/scripts/configure_gnome.sh
+++ b/scripts/configure_gnome.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ouex pipefail
-
-sed -i "/^favorite-apps=/s/\[.*\]/['org.gnome.Ptyxis.desktop', 'io.github.zen_browser.zen.desktop', 'org.gnome.Nautilus.desktop', 'dev.zed.Zed.desktop', 'dev.vencord.Vesktop.desktop', 'com.spotify.Client.desktop', 'steam.desktop', 'org.gnome.Software.desktop']/" /etc/dconf/db/local.d/03-bazzite-dash
-
-sed -i 's/tap-to-click=true/tap-to-click=false/' /etc/dconf/db/gdm.d/02-bazzite-global
-
-sed -i 's/tap-to-click=true/tap-to-click=false/' /etc/dconf/db/local.d/02-bazzite-global

--- a/scripts/configure_kde.sh
+++ b/scripts/configure_kde.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ouex pipefail
+
+# Configure Taskbar
+sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>applications:org.gnome.Ptyxis.desktop,preferred:\/\/browser,preferred:\/\/filemanager,applications:code.desktop,applications:steam.desktop<\/default>/' /usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml
+
+# Configure Favorites
+sed -i '/<entry name="favorites" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>org.gnome.Ptyxis.desktop,preferred:\/\/browser,org.kde.dolphin.desktop,code.desktop,steam.desktop<\/default>/' /usr/share/plasma/plasmoids/org.kde.plasma.kickoff/contents/config/main.xml

--- a/system_files/usr/share/ublue-os/just/80-isengard.just
+++ b/system_files/usr/share/ublue-os/just/80-isengard.just
@@ -19,7 +19,7 @@ disconnect-home:
 # Install system flatpaks
 _install-isengard-flatpaks:
     #!/bin/bash
-    BAZZITE_FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/bazzite/main/installer/gnome_flatpaks/flatpaks | tr '\n' ' ')"
+    BAZZITE_FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/bazzite/main/scripts/kde_flatpaks/flatpaks | tr '\n' ' ')"
     ISENGARD_FLATPAK_LIST="$(curl https://raw.githubusercontent.com/noelmiller/isengard/main/flatpaks/isengard_flatpaks | tr '\n' ' ')"
     echo "Installing Bazzite Flatpaks.."
     flatpak --system -y install ${BAZZITE_FLATPAK_LIST}


### PR DESCRIPTION
Window Capture through OBS is broken under Gnome. Cannot switch unless they fix it.